### PR TITLE
lオプションの追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -22,6 +22,33 @@ class String
   end
 end
 
+def add_suid_permission(permission)
+  permission[2] =
+    if permission[2] == 'x'
+      's'
+    else
+      'S'
+    end
+end
+
+def add_sgid_permission(permission)
+  permission[2] =
+    if permission[2] == 'x'
+      's'
+    else
+      'S'
+    end
+end
+
+def add_sticiky_permission(permission)
+  permission[2] =
+    if permission[2] == 'x'
+      't'
+    else
+      'T'
+    end
+end
+
 class File::Stat
   def filetype
     {
@@ -38,7 +65,18 @@ class File::Stat
 
   def mode_formatted
     modes = ['---', '--x', '-w-', '-wx', 'r--', 'r-x', 'rw-', 'rwx']
-    mode.to_s(8)[-3..].chars.map { |num| modes[num.to_i] }.join
+    mode.to_s(8)[-3..].chars.map.with_index do |num, idx|
+      permission = modes[num.to_i].dup
+      case idx # 特殊権限を持つ場合の分岐
+      when 0
+        permission = add_suid_permission(permission) if setuid?
+      when 1
+        permission = add_sgid_permission(permission) if setgid?
+      when 2
+        permission = add_sticiky_permission(permission) if sticky?
+      end
+      permission
+    end.join
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -132,8 +132,7 @@ OptionParser.new do |o|
   o.on('-a') { a_option = true }
   o.on('-r') { r_option = true }
   o.on('-l') { l_option = true }
-  # TODO:	後のプラクティスで実装
-
+  
   o.parse!(ARGV) # パス指定オプションが入る
 rescue OptionParser::InvalidOption => e
   puts e.message

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,6 +2,7 @@
 
 require 'date'
 require 'optparse'
+require 'etc'
 
 UPPER_LIMIT_COLUMN_COUNT = 3 # > 0
 
@@ -18,6 +19,26 @@ class String
   def mb_ljust(width, padding = ' ')
     padding_size = [0, width - exact_size].max
     self + padding * padding_size
+  end
+end
+
+class File::Stat
+  def filetype
+    {
+      'file' => '-',
+      'directory' => 'd',
+      'characterSpecial' => 'c',
+      'blockSpecial' => 'b',
+      'fifo' => 'p',
+      'link' => 'l',
+      'socket' => 's',
+      'unknown' => '?'
+    }[ftype]
+  end
+
+  def mode_formatted
+    modes = ['---', '--x', '-w-', '-wx', 'r--', 'r-x', 'rw-', 'rwx']
+    mode.to_s(8)[-3..].chars.map { |num| modes[num.to_i] }.join
   end
 end
 
@@ -49,16 +70,69 @@ def ls_display_matrix(file_dir_list, upper_limit_column_count, column_padding_si
   end
 end
 
+def make_files_info(file_dir_list, path)
+  total_blocks = 0
+  list = file_dir_list.map do |n|
+    fs = File::Stat.new("#{path}/#{n}")
+    total_blocks += fs.blocks
+    {
+      mode: fs.filetype + fs.mode_formatted,
+      num_link: fs.nlink,
+      owner: Etc.getpwuid(fs.uid).name,
+      group: Etc.getgrgid(fs.gid).name,
+      file_size: fs.size,
+      time: format_time_by_modification(fs.mtime),
+      path: name_with_symlink_target_if_exists(path, n)
+    }
+  end
+  [total_blocks, list]
+end
+
+def ls_display_long_format(hash_list, widths)
+  hash_list.each do |info_hash|
+    info_hash.each do |key, value|
+      value = value.to_s.rjust(widths[key], ' ') if widths.key?(key)
+      print "#{value} "
+    end
+    puts
+  end
+end
+
+def calculate_max_widths(hash_list)
+  {
+    num_link: hash_list.max_by { |hash| hash[:num_link].to_s.length }[:num_link].to_s.length,
+    owner: hash_list.max_by { |hash| hash[:owner].length }[:owner].length,
+    group: hash_list.max_by { |hash| hash[:group].length }[:group].length,
+    file_size: hash_list.max_by { |hash| hash[:file_size].to_s.length }[:file_size].to_s.length
+  }
+end
+
+def format_time_by_modification(time)
+  # 現在日時から6か月前の日時を計算
+  six_months_ago = Time.now - (60 * 60 * 24 * 30 * 6)
+
+  # ファイルの最終更新日時が6か月前よりも後であれば
+  return time.strftime('%b %e %R') if time > six_months_ago
+
+  time.strftime('%b %e  %G')
+end
+
+def name_with_symlink_target_if_exists(path, name)
+  return name unless File.symlink?("#{path}/#{name}")
+
+  "#{name} -> #{File.readlink("#{path}/#{name}")}"
+end
+
 a_option = false
 r_option = false
+l_option = false
 
 # コマンドライン引数の取得
 OptionParser.new do |o|
   o.on('-a') { a_option = true }
   o.on('-r') { r_option = true }
-
+  o.on('-l') { l_option = true }
   # TODO:	後のプラクティスで実装
-  o.on('-l') {}
 
   o.parse!(ARGV) # パス指定オプションが入る
 rescue OptionParser::InvalidOption => e
@@ -69,21 +143,22 @@ end
 path_list = ARGV[0] ? ARGV : ['.']
 
 path_list.each do |path|
-  if File.exist?(path)
-    if File.directory?(path)
-      file_dir_list =
-        if a_option
-          Dir.glob('*', flags: File::FNM_DOTMATCH, base: path).map { |m| File.basename(m) }
-        else
-          Dir.glob('*', base: path).map { |m| File.basename(m) }
-        end
-      file_dir_list.reverse! if r_option
-      ls_display_matrix(file_dir_list, UPPER_LIMIT_COLUMN_COUNT, COLUMN_PADDING_SIZE)
+  puts "ls: cannot access '#{path}': No such file or directory" unless File.exist?(path)
+  puts File.basename(path) unless File.directory?(path)
+
+  file_dir_list =
+    if a_option
+      Dir.glob('*', flags: File::FNM_DOTMATCH, base: path).map { |m| File.basename(m) }
     else
-      puts File.basename(path)
+      Dir.glob('*', base: path).map { |m| File.basename(m) }
     end
-    puts
+  file_dir_list.reverse! if r_option
+  if l_option
+    total_blocks, files_info = make_files_info(file_dir_list, path)
+    puts "total #{total_blocks}"
+    ls_display_long_format(files_info, calculate_max_widths(files_info))
   else
-    puts "ls: cannot access '#{path}': No such file or directory"
+    ls_display_matrix(file_dir_list, UPPER_LIMIT_COLUMN_COUNT, COLUMN_PADDING_SIZE)
   end
+  puts
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -146,8 +146,14 @@ end
 path_list = ARGV[0] ? ARGV : ['.']
 
 path_list.each do |path|
-  puts "ls: cannot access '#{path}': No such file or directory" unless File.exist?(path)
-  puts File.basename(path) unless File.directory?(path)
+  unless File.exist?(path)
+    puts "ls: cannot access '#{path}': No such file or directory"
+    exit
+  end
+  unless File.directory?(path)
+    puts File.basename(path) unless File.directory?(path)
+    exit
+  end
 
   file_dir_list =
     if a_option

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -206,6 +206,8 @@ path_list.each do |path|
     exit
   end
 
+  next if Dir.empty?(path)
+
   file_dir_list =
     if a_option
       Dir.glob('*', flags: File::FNM_DOTMATCH, base: path).map { |m| File.basename(m) }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -89,7 +89,9 @@ def make_files_info(file_dir_list, path)
       path: name_with_symlink_target_if_exists(path, n)
     }
   end
-  [total_blocks, list]
+  # ブロック数割り当ての基準が、File.Statでは512Byte,Linux(ls)では1024Byteであるため、
+  # total_block数に差がでる。その問題を解消するために2で割る。
+  [total_blocks / 2, list]
 end
 
 def ls_display_long_format(hash_list, widths)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -69,18 +69,15 @@ class File::Stat
   def mode_formatted
     modes = ['---', '--x', '-w-', '-wx', 'r--', 'r-x', 'rw-', 'rwx']
     mode.to_s(8)[-3..].chars.map.with_index do |num, idx|
-      permission =
-        case idx # 特殊権限を持つ場合の分岐
-        when 0
-          add_suid_permission(modes[num.to_i].dup) if setuid?
-        when 1
-          add_sgid_permission(modes[num.to_i].dup) if setgid?
-        when 2
-          add_sticiky_permission(modes[num.to_i].dup) if sticky?
-        end
-
-      # 通常権限(後置ifがfalse)の場合はpermissionにnilが入るので ||　で対応
-      permission || modes[num.to_i].dup
+      if idx.zero? && setuid?
+        add_suid_permission(modes[num.to_i].dup)
+      elsif (idx == 1) && setuid?
+        add_sgid_permission(modes[num.to_i].dup)
+      elsif (idx == 2) && sticky?
+        add_sticiky_permission(modes[num.to_i].dup)
+      else
+        modes[num.to_i].dup
+      end
     end.join
   end
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -29,6 +29,7 @@ def add_suid_permission(permission)
     else
       'S'
     end
+  permission
 end
 
 def add_sgid_permission(permission)
@@ -38,6 +39,7 @@ def add_sgid_permission(permission)
     else
       'S'
     end
+  permission
 end
 
 def add_sticiky_permission(permission)
@@ -47,6 +49,7 @@ def add_sticiky_permission(permission)
     else
       'T'
     end
+  permission
 end
 
 class File::Stat

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -216,9 +216,8 @@ path_list.each do |path|
     end
   file_dir_list.reverse! if r_option
   if l_option
-    total_blocks = calculate_total_blocks(file_dir_list, path)
     files_details = details_in_long_format(file_dir_list, path)
-    puts "total #{total_blocks}"
+    puts "total #{calculate_total_blocks(file_dir_list, path)}"
     ls_display_long_format(files_details, calculate_max_widths(files_details))
   else
     ls_display_matrix(file_dir_list, UPPER_LIMIT_COLUMN_COUNT, COLUMN_PADDING_SIZE)


### PR DESCRIPTION
lsコマンドのlオプションを追加しました。

a,rオプションも利用できます。 ~~（しかし、-larのようには指定できないです。）~~